### PR TITLE
Add slippage rate calculations to Fulcrum's trade form

### DIFF
--- a/packages/fulcrum/src/components/TradeForm.tsx
+++ b/packages/fulcrum/src/components/TradeForm.tsx
@@ -83,6 +83,7 @@ interface ITradeFormState {
   slippageRate: BigNumber
   ethBalance: BigNumber
   depositTokenBalance: BigNumber
+  collateralToPrincipalRate: BigNumber
 
   baseTokenPrice: BigNumber
   returnedAsset: Asset
@@ -116,6 +117,7 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
       interestRate: new BigNumber(0),
       slippageRate: new BigNumber(0),
       ethBalance: new BigNumber(0),
+      collateralToPrincipalRate: new BigNumber(0),
       depositTokenBalance: new BigNumber(0),
       maybeNeedsApproval: false,
       liquidationPrice: liquidationPrice,
@@ -262,7 +264,8 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
         isExposureLoading: false,
         isLoading: false,
         ethBalance,
-        depositTokenBalance
+        depositTokenBalance,
+        collateralToPrincipalRate
       })
   }
 
@@ -303,10 +306,12 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
       this.props.positionType === PositionType.LONG ? this.props.baseToken : this.props.quoteToken
     const srcToken =
       this.props.positionType === PositionType.LONG ? this.props.quoteToken : this.props.baseToken
-    const slippageRate = await FulcrumProvider.Instance.getTradeSlippageRate(
+    const tradeAmountInLoanToken = this.state.depositToken === srcToken ? tradeAmount.times(this.props.leverage)
+    : tradeAmount.times(this.state.collateralToPrincipalRate).times(this.props.leverage)
+      const slippageRate = await FulcrumProvider.Instance.getTradeSlippageRate(
       srcToken,
       destToken,
-      tradeAmount
+      tradeAmountInLoanToken
     )
     this.setState({ ...this.state, slippageRate })
   }

--- a/packages/fulcrum/src/components/TradeForm.tsx
+++ b/packages/fulcrum/src/components/TradeForm.tsx
@@ -285,7 +285,7 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
 
   public async componentDidMount() {
     this._isMounted = true
-    await this.setSlippageRate(new BigNumber(1))
+    await this.setSlippageRate(new BigNumber(0))
     await this.derivedUpdate()
     window.history.pushState(
       null,
@@ -306,9 +306,11 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
       this.props.positionType === PositionType.LONG ? this.props.baseToken : this.props.quoteToken
     const srcToken =
       this.props.positionType === PositionType.LONG ? this.props.quoteToken : this.props.baseToken
-    const tradeAmountInLoanToken = this.state.depositToken === srcToken ? tradeAmount.times(this.props.leverage)
-    : tradeAmount.times(this.state.collateralToPrincipalRate).times(this.props.leverage)
-      const slippageRate = await FulcrumProvider.Instance.getTradeSlippageRate(
+    const tradeAmountInLoanToken =
+      this.state.depositToken === srcToken
+        ? tradeAmount.times(this.props.leverage)
+        : tradeAmount.times(this.state.collateralToPrincipalRate).times(this.props.leverage)
+    const slippageRate = await FulcrumProvider.Instance.getTradeSlippageRate(
       srcToken,
       destToken,
       tradeAmountInLoanToken

--- a/packages/fulcrum/src/components/TradeForm.tsx
+++ b/packages/fulcrum/src/components/TradeForm.tsx
@@ -23,7 +23,7 @@ import InputReceive from './InputReceive'
 import { PositionTypeMarkerAlt } from './PositionTypeMarkerAlt'
 import { Preloader } from './Preloader'
 import { TradeExpectedResult } from './TradeExpectedResult'
-
+import { ReactComponent as SlippageDown } from '../assets/images/ic__slippage_down.svg'
 import '../styles/components/trade-form.scss'
 
 const isMainnetProd =
@@ -80,6 +80,10 @@ interface ITradeFormState {
   isLoading: boolean
   isExposureLoading: boolean
 
+  slippageRate: BigNumber
+  ethBalance: BigNumber
+  depositTokenBalance: BigNumber
+
   baseTokenPrice: BigNumber
   returnedAsset: Asset
   returnedAmount: BigNumber
@@ -96,7 +100,7 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
 
   constructor(props: ITradeFormProps, context?: any) {
     super(props, context)
-    const assetDetails = AssetsDictionary.assets.get(props.baseToken)   
+    const assetDetails = AssetsDictionary.assets.get(props.baseToken)
     const maxTradeValue = new BigNumber(0)
     const liquidationPrice = new BigNumber(0)
     const exposureValue = new BigNumber(0)
@@ -110,6 +114,9 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
       maxTradeValue: maxTradeValue,
       buttonValue: 0,
       interestRate: new BigNumber(0),
+      slippageRate: new BigNumber(0),
+      ethBalance: new BigNumber(0),
+      depositTokenBalance: new BigNumber(0),
       maybeNeedsApproval: false,
       liquidationPrice: liquidationPrice,
       exposureValue: exposureValue,
@@ -234,6 +241,11 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
       exposureValue = estimatedMargin.exposureValue
       interestRate = estimatedMargin.interestRate
     }
+
+    const ethBalance = await FulcrumProvider.Instance.getEthBalance()
+    const depositTokenBalance = await FulcrumProvider.Instance.getAssetTokenBalanceOfUser(
+      this.state.depositToken
+    )
     this._isMounted &&
       this.setState({
         ...this.state,
@@ -248,7 +260,9 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
         baseTokenPrice,
         exposureValue: exposureValue,
         isExposureLoading: false,
-        isLoading: false
+        isLoading: false,
+        ethBalance,
+        depositTokenBalance
       })
   }
 
@@ -268,7 +282,7 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
 
   public async componentDidMount() {
     this._isMounted = true
-
+    await this.setSlippageRate(new BigNumber(1))
     await this.derivedUpdate()
     window.history.pushState(
       null,
@@ -284,11 +298,30 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
     }
   }
 
+  private async setSlippageRate(tradeAmount: BigNumber) {
+    const destToken =
+      this.props.positionType === PositionType.LONG ? this.props.baseToken : this.props.quoteToken
+    const srcToken =
+      this.props.positionType === PositionType.LONG ? this.props.quoteToken : this.props.baseToken
+    const slippageRate = await FulcrumProvider.Instance.getTradeSlippageRate(
+      srcToken,
+      destToken,
+      tradeAmount
+    )
+    this.setState({ ...this.state, slippageRate })
+  }
+
   public componentDidUpdate(
     prevProps: Readonly<ITradeFormProps>,
     prevState: Readonly<ITradeFormState>,
     snapshot?: any
   ): void {
+    if (
+      this.state.depositToken !== prevState.depositToken ||
+      this.state.tradeAmountValue !== prevState.tradeAmountValue
+    ) {
+      this.setSlippageRate(this.state.tradeAmountValue)
+    }
     if (
       this.props.tradeType !== prevProps.tradeType ||
       this.props.baseToken !== prevProps.baseToken ||
@@ -330,17 +363,14 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
         ? 'trade-form__submit-button--buy'
         : 'trade-form__submit-button--sell'
 
-    // const amountMsg =
-    //   this.state.ethBalance && this.state.ethBalance.lte(FulcrumProvider.Instance.gasBufferForTrade)
-    //     ? "Insufficient funds for gas"
-    //     : this.state.balance && this.state.balance.eq(0)
-    //       ? "Your wallet is empty"
-    //       : (this.state.tradeAmountValue.gt(0) && this.state.slippageRate.eq(0))
-    //         && (this.state.depositToken === Asset.ETH || !this.state.maybeNeedsApproval)
-    //         ? ``// `Your trade is too small.`
-    //         : this.state.slippageRate.gte(0.01) && this.state.slippageRate.lt(99) // gte(0.2)
-    //           ? `Slippage:`
-    //           : "";
+    const amountMsg =
+      this.state.ethBalance && this.state.ethBalance.lte(FulcrumProvider.Instance.gasBufferForTrade)
+        ? 'Insufficient funds for gas'
+        : this.state.depositTokenBalance && this.state.depositTokenBalance.eq(0)
+        ? 'Your wallet is empty'
+        : this.state.slippageRate.gte(0.01) && this.state.slippageRate.lt(99) // gte(0.2)
+        ? `Slippage:`
+        : ''
 
     let submitButtonText = ``
     if (this.props.tradeType === TradeType.BUY) {
@@ -396,17 +426,21 @@ export default class TradeForm extends Component<ITradeFormProps, ITradeFormStat
               />
             ) : null}
 
-            {/*<div className="trade-form__kv-container">
-              {amountMsg.includes("Slippage:") ? (
-                <div title={`${this.state.slippageRate.toFixed(18)}%`} className="trade-form__label slippage">
+            <div className="trade-form__kv-container">
+              {amountMsg.includes('Slippage:') ? (
+                <div
+                  title={`${this.state.slippageRate.toFixed(18)}%`}
+                  className="trade-form__label slippage">
                   {amountMsg}
                   <span className="trade-form__slippage-amount">
-                    &nbsp;{`${this.state.slippageRate.toFixed(2)}%`}<SlippageDown />
+                    &nbsp;{`${this.state.slippageRate.toFixed(2)}%`}
+                    <SlippageDown />
                   </span>
                 </div>
-              ) : (<div className="trade-form__label">{amountMsg}</div>)}
-
-            </div> */}
+              ) : (
+                <div className="trade-form__label">{amountMsg}</div>
+              )}
+            </div>
 
             <InputAmount
               inputAmountText={this.state.inputAmountText}

--- a/packages/fulcrum/src/services/FulcrumProvider.ts
+++ b/packages/fulcrum/src/services/FulcrumProvider.ts
@@ -1238,23 +1238,37 @@ export class FulcrumProvider {
     return maybeNeedsApproval
   }
 
-  
-  public getTradeSlippageRate = async (srcToken: Asset, destToken: Asset, tradedAmountEstimate: BigNumber): Promise<BigNumber> => {
-
+  public getTradeSlippageRate = async (
+    srcToken: Asset,
+    destToken: Asset,
+    tradedAmountEstimate: BigNumber
+  ): Promise<BigNumber> => {
     if (tradedAmountEstimate.eq(0) || srcToken === destToken) {
-      return new BigNumber(0);
+      return new BigNumber(0)
     }
-    
-      const srcDecimals = AssetsDictionary.assets.get(srcToken)?.decimals || 18;
-      const amount = tradedAmountEstimate.times(10 ** srcDecimals)
-      const srcAssetErc20Address = FulcrumProvider.Instance.getErc20AddressOfAsset(srcToken);
-      const destAssetErc20Address = FulcrumProvider.Instance.getErc20AddressOfAsset(destToken);
-      const slippageJsonOneToken = await fetch(`https://api.kyber.network/expectedRate?source=${srcAssetErc20Address}&dest=${destAssetErc20Address}&sourceAmount=${10 ** srcDecimals}`).then(resp => resp.json())
-      const slippageJsonMaxValue = await fetch(`https://api.kyber.network/expectedRate?source=${srcAssetErc20Address}&dest=${destAssetErc20Address}&sourceAmount=${amount}`).then(resp => resp.json())
 
-    const slippage = new BigNumber(slippageJsonOneToken.expectedRate).minus(slippageJsonMaxValue.expectedRate).abs().div(slippageJsonMaxValue.expectedRate).times(100)
+    const srcDecimals = AssetsDictionary.assets.get(srcToken)?.decimals || 18
+    const amount = tradedAmountEstimate.times(10 ** srcDecimals)
+    const srcAssetErc20Address = FulcrumProvider.Instance.getErc20AddressOfAsset(srcToken)
+    const destAssetErc20Address = FulcrumProvider.Instance.getErc20AddressOfAsset(destToken)
+    const slippageJsonOneTokenWorth = await fetch(
+      `https://api.kyber.network/expectedRate?source=${srcAssetErc20Address}&dest=${destAssetErc20Address}&sourceAmount=${10 **
+        srcDecimals}`
+    ).then((resp) => resp.json())
+    const slippageJsonTradeAmount = await fetch(
+      `https://api.kyber.network/expectedRate?source=${srcAssetErc20Address}&dest=${destAssetErc20Address}&sourceAmount=${amount}`
+    ).then((resp) => resp.json())
 
-    return slippage;
+    if (!slippageJsonOneTokenWorth.expectedRate || !slippageJsonTradeAmount.expectedRate) {
+      return new BigNumber(0)
+    }
+    const slippage = new BigNumber(slippageJsonOneTokenWorth.expectedRate)
+      .minus(slippageJsonTradeAmount.expectedRate)
+      .abs()
+      .div(slippageJsonTradeAmount.expectedRate)
+      .times(100)
+
+    return slippage
   }
 
   // public getTradeSlippageRate = async (request: TradeRequest, tradedAmountEstimate: BigNumber): Promise<BigNumber | null> => {

--- a/packages/torque/src/components/BorrowForm.tsx
+++ b/packages/torque/src/components/BorrowForm.tsx
@@ -92,7 +92,7 @@ export class BorrowForm extends Component<IBorrowFormProps, IBorrowFormState> {
     this._input = input
   }
 
-  public async componentWillMount() {
+  private async setDefaultCollaterization(){
     const minInitialMargin = await TorqueProvider.Instance.getMinInitialMargin(
       this.props.borrowAsset,
       this.state.collateralAsset
@@ -106,16 +106,23 @@ export class BorrowForm extends Component<IBorrowFormProps, IBorrowFormState> {
       collateralValue: selectedValue.toFixed()
     })
   }
-  public componentDidUpdate(
+
+  public async componentWillMount() {
+    await this.setDefaultCollaterization()
+  }
+  public async componentDidUpdate(
     prevProps: Readonly<IBorrowFormProps>,
     prevState: Readonly<IBorrowFormState>,
     snapshot?: any
-  ): void {
+  ) {
     if (
       this.state.depositAmount !== prevState.depositAmount ||
       this.state.collateralAsset !== prevState.collateralAsset
     ) {
       this.changeStateLoading()
+    }
+    if (prevState.collateralAsset !== this.state.collateralAsset){
+      await this.setDefaultCollaterization()
     }
   }
 

--- a/packages/torque/src/components/BorrowForm.tsx
+++ b/packages/torque/src/components/BorrowForm.tsx
@@ -437,5 +437,7 @@ export class BorrowForm extends Component<IBorrowFormProps, IBorrowFormState> {
       selectedValue: selectedValue,
       collateralValue: selectedValue.toFixed(2)
     })
+    
+    this._inputTextChange.next(this.state.inputAmountText)
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/bzx1/story/846/not-a-bug-really-show-user-slippage-on-fulcrum
https://app.clubhouse.io/bzx1/story/466/add-slippage-indicator-to-fulcrum-tradeform

Slippage calculation was implement base on [Kyber docs](https://developer.kyber.network/docs/Integrations-SlippageRateProtection/#method-2-display-rate-slippage-in-the-user-interface)

For any margin loan, we swap loan token for collateral token. So `srcToken` is always the loan token and `destToken` is collateral one. Users are able to deposit either in collateral token or in loan token. 

When the user deposits in loan token I just multiply this amount by leverage and get the actual swap amount of `srcToken`. 
When the user deposits in collateral token I multiply it by collateralToLoan rate to get deposit worth in loan token denomination, then multiply it by leverage and get the actual swap amount of `srcToken`. 