### PR TITLE
Fulcrum: fix collateral column on trade page for old loans

### DIFF
--- a/packages/fulcrum/src/components/OwnTokenGridRow.tsx
+++ b/packages/fulcrum/src/components/OwnTokenGridRow.tsx
@@ -294,7 +294,7 @@ export class OwnTokenGridRow extends Component<IOwnTokenGridRowProps, IOwnTokenG
         </div>
         <div className="own-token-grid-row__col-collateral opacityIn">
           <span className="body-header">Collateral&nbsp;</span>
-          <span className="own-token-grid-row__asset">{this.props.quoteToken}</span>
+          <span className="own-token-grid-row__asset">{this.props.baseToken}</span>
           <br />
           <div>
           <div

--- a/packages/fulcrum/src/pages/TradePage.tsx
+++ b/packages/fulcrum/src/pages/TradePage.tsx
@@ -600,7 +600,7 @@ export default class TradePage extends PureComponent<ITradePageProps, ITradePage
     if (positionType === PositionType.LONG) {
       positionValue = collateralAssetAmount
       value = collateralAssetAmount.times(currentCollateralToPrincipalRate)
-      collateral = collateralAssetAmount.times(currentCollateralToPrincipalRate)
+      collateral = collateralAssetAmount
 
       openPrice = loan.loanData.startRate
         .div(10 ** 18)
@@ -609,7 +609,6 @@ export default class TradePage extends PureComponent<ITradePageProps, ITradePage
       liquidationPrice = liquidation_collateralToLoanRate.div(10 ** 18)
 
       if (
-        isRolloverPending ||
         loan.loanData.depositValueAsCollateralToken.eq(0) ||
         loan.loanData.depositValueAsLoanToken.eq(0)
       ) {
@@ -641,7 +640,7 @@ export default class TradePage extends PureComponent<ITradePageProps, ITradePage
           : undefined
       }
     } else {
-      collateral = collateralAssetAmount
+      collateral = collateralAssetAmount.times(currentCollateralToPrincipalRate)
 
       const shortsDiff = collateralAssetAmount
         .times(currentCollateralToPrincipalRate)
@@ -658,7 +657,6 @@ export default class TradePage extends PureComponent<ITradePageProps, ITradePage
       liquidationPrice = new BigNumber(10 ** 36).div(liquidation_collateralToLoanRate).div(10 ** 18)
 
       if (
-        isRolloverPending ||
         loan.loanData.depositValueAsCollateralToken.eq(0) ||
         loan.loanData.depositValueAsLoanToken.eq(0)
       ) {


### PR DESCRIPTION
https://app.clubhouse.io/bzx1/story/1326/collateral-eth-is-shows-as-a-usdt-value-and-not-an-eth-value