### PR TITLE
Explorer: update events fetching

### DIFF
--- a/packages/protocol-explorer/src/components/AppRouter.tsx
+++ b/packages/protocol-explorer/src/components/AppRouter.tsx
@@ -136,12 +136,12 @@ export class AppRouter extends Component<any, IAppRouterState> {
                     doNetworkConnect={this.doNetworkConnect}
                   />
                 </Route>
-                <Route path="/loan-params">
+                {/* <Route path="/loan-params">
                   <LoanParamsPage
                     isMobileMedia={this.state.isMobileMedia}
                     doNetworkConnect={this.doNetworkConnect}
                   />
-                </Route>
+                </Route> */}
               </Switch>
             </Router>
             <Footer />

--- a/packages/protocol-explorer/src/components/Search.tsx
+++ b/packages/protocol-explorer/src/components/Search.tsx
@@ -39,10 +39,16 @@ export const Search = (props: ISearchProps) => {
     setInputValue('')
     props.onSearch('')
   }
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const input = _input.current
+    const value = input ? input.value : ''
+    props.onSearch(value.toLowerCase())
+  }
 
   return (
     <React.Fragment>
-      <form className={`search ${isFocus ? `focus` : ``}`}>
+      <form className={`search ${isFocus ? `focus` : ``}`} onSubmit={onSubmit}>
         <input
           ref={_input}
           placeholder="Search"

--- a/packages/protocol-explorer/src/components/Search.tsx
+++ b/packages/protocol-explorer/src/components/Search.tsx
@@ -58,12 +58,12 @@ export const Search = (props: ISearchProps) => {
           value={inputValue}
         />
         {inputValue.length > 0 && (
-          <button onClick={resetInput}>
+          <button type="button" onClick={resetInput}>
             <IconClear />
           </button>
         )}
         {inputValue.length === 0 && (
-          <button onClick={onSearchClick}>
+          <button type="button" onClick={onSearchClick}>
             {' '}
             <IconSearch />
           </button>

--- a/packages/protocol-explorer/src/components/TxGrid.tsx
+++ b/packages/protocol-explorer/src/components/TxGrid.tsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import { TxRow, ITxRowProps } from './TxRow'
 import { IconSort } from './IconSort'
+import { ReactComponent as ArrowPagination } from '../assets/images/icon_pagination.svg'
+
 interface ITxGridProps {
   events: ITxRowProps[]
   quantityTx: number
@@ -8,24 +10,56 @@ interface ITxGridProps {
 
 interface ITxGridState {
   typeSort: string
+  numberPagination: number
+  quantityGrids: number
+  isLastRow: boolean
 }
 
 export class TxGrid extends Component<ITxGridProps, ITxGridState> {
+  private quantityVisibleRow = 25
+
   constructor(props: any) {
     super(props)
     this.state = {
-      typeSort: 'up'
+      typeSort: 'up',
+      numberPagination: 0,
+      quantityGrids: 0,
+      isLastRow: false
+    }
+    this.quantityVisibleRow = props.quantityTx
+  }
+
+  public componentDidMount(): void {
+    const quantityGrids = Math.floor(this.props.events.length / this.quantityVisibleRow)
+    const isLastRow =
+      this.props.events.length === (this.state.numberPagination + 1) * this.quantityVisibleRow
+    this.setState({ ...this.state, quantityGrids: quantityGrids, isLastRow: isLastRow })
+  }
+
+  public componentDidUpdate(
+    prevProps: Readonly<ITxGridProps>,
+    prevState: Readonly<ITxGridState>,
+    snapshot?: any
+  ): void {
+    if (this.props.events !== prevProps.events) {
+      const quantityGrids = Math.floor(this.props.events.length / this.quantityVisibleRow)
+      const isLastRow =
+        this.props.events.length === (this.state.numberPagination + 1) * this.quantityVisibleRow
+      this.setState({ ...this.state, quantityGrids: quantityGrids, isLastRow: isLastRow })
     }
   }
 
   public render() {
     const assetItems = this.props.events
-      .sort((a, b) => {
+      .sort((a: ITxRowProps, b: ITxRowProps) => {
         return this.state.typeSort === 'up'
-          ? b.age.getTime() - a.age.getTime()
-          : a.age.getTime() - b.age.getTime()
+          ? b.blockNumber.minus(a.blockNumber).toNumber()
+          : a.blockNumber.minus(b.blockNumber).toNumber()
       })
-      .slice(0, this.props.quantityTx)
+      .slice(
+        this.quantityVisibleRow * this.state.numberPagination,
+        this.quantityVisibleRow * this.state.numberPagination + this.quantityVisibleRow
+      )
       .map((e: ITxRowProps, i: number) => <TxRow key={i} {...e} />)
     return (
       <React.Fragment>
@@ -44,8 +78,48 @@ export class TxGrid extends Component<ITxGridProps, ITxGridState> {
             {assetItems}
           </div>
         )}
+        {this.props.events.length > this.quantityVisibleRow && (
+          <div className="pagination">
+            <div
+              className={`prev ${this.state.numberPagination === 0 ? `disabled` : ``}`}
+              onClick={this.prevPagination}>
+              <ArrowPagination />
+            </div>
+            <div
+              className={`next ${
+                this.state.numberPagination === this.state.quantityGrids || this.state.isLastRow
+                  ? `disabled`
+                  : ``
+              }`}
+              onClick={this.nextPagination}>
+              <ArrowPagination />
+            </div>
+          </div>
+        )}
       </React.Fragment>
     )
+  }
+
+  public nextPagination = () => {
+    if (this.state.numberPagination !== this.state.quantityGrids && !this.state.isLastRow) {
+      const isLastRow =
+        this.props.events.length === (this.state.numberPagination + 2) * this.quantityVisibleRow
+      this.setState({
+        ...this.state,
+        numberPagination: this.state.numberPagination + 1,
+        isLastRow: isLastRow
+      })
+    }
+  }
+
+  public prevPagination = () => {
+    if (this.state.numberPagination !== 0) {
+      this.setState({
+        ...this.state,
+        numberPagination: this.state.numberPagination - 1,
+        isLastRow: false
+      })
+    }
   }
 
   public sortAge = () => {

--- a/packages/protocol-explorer/src/components/TxRow.tsx
+++ b/packages/protocol-explorer/src/components/TxRow.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { ReactComponent as IconArrow } from '../assets/images/icon-tx-arrow.svg'
 import { BigNumber } from '@0x/utils'
 import Asset from 'bzx-common/src/assets/Asset'
+import { ExplorerProvider } from '../services/ExplorerProvider'
 
 export interface ITxRowProps {
   hash: string
   etherscanTxUrl: string
-  age: Date
+  blockNumber: BigNumber
   account: string
   etherscanAddressUrl: string
   quantity: BigNumber
@@ -15,7 +16,18 @@ export interface ITxRowProps {
 }
 
 export const TxRow = (props: ITxRowProps) => {
-  const timeSince = (date: Date) => {
+  const [age, setAge] = React.useState<string>('...')
+  React.useEffect(() => {
+    timeSince(props.blockNumber).then(setAge)
+  }, [])
+  React.useEffect(() => {
+    timeSince(props.blockNumber).then(setAge)
+  }, [props.hash])
+  const timeSince = async (blockNumber: BigNumber) => {
+    const blockTimestamp = await ExplorerProvider.Instance.web3Wrapper!.getBlockTimestampAsync(
+      blockNumber.toNumber()
+    )
+    const date = new Date(blockTimestamp * 1000)
     var seconds = Math.floor((new Date().getTime() - date.getTime()) / 1000)
 
     var interval = Math.floor(seconds / 31536000)
@@ -54,7 +66,7 @@ export const TxRow = (props: ITxRowProps) => {
           className="table-row-tx__hash">
           {getShortHash(props.hash, 12)}
         </a>
-        <div className="table-row-tx__age">{timeSince(props.age)} ago</div>
+        <div className="table-row-tx__age">{age} ago</div>
         <a
           href={props.etherscanAddressUrl}
           target="_blank"

--- a/packages/protocol-explorer/src/domain/BorrowEvent.ts
+++ b/packages/protocol-explorer/src/domain/BorrowEvent.ts
@@ -15,7 +15,7 @@ export class BorrowEvent {
   public readonly interestDuration: BigNumber
   public readonly collateralToLoanRate: BigNumber // one unit of loanToken, denominated in collateralToken
   public readonly currentMargin: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
 
   constructor(
@@ -30,7 +30,7 @@ export class BorrowEvent {
     interestDuration: BigNumber,
     collateralToLoanRate: BigNumber,
     currentMargin: BigNumber,
-    timeStamp: Date,
+    blockNumber: BigNumber,
     txHash: string
   ) {
     this.user = user
@@ -44,7 +44,7 @@ export class BorrowEvent {
     this.interestDuration = interestDuration
     this.collateralToLoanRate = collateralToLoanRate
     this.currentMargin = currentMargin
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
   }
 }

--- a/packages/protocol-explorer/src/domain/BurnEvent.ts
+++ b/packages/protocol-explorer/src/domain/BurnEvent.ts
@@ -8,7 +8,7 @@ export class BurnEvent {
   public readonly tokenAmount: BigNumber
   public readonly assetAmount: BigNumber
   public readonly price: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
   public readonly asset: Asset
 
@@ -17,7 +17,7 @@ export class BurnEvent {
     tokenAmount: BigNumber,
     assetAmount: BigNumber,
     price: BigNumber,
-    timeStamp: Date,
+    blockNumber: BigNumber,
     txHash: string,
     asset: Asset
   ) {
@@ -25,7 +25,7 @@ export class BurnEvent {
     this.tokenAmount = tokenAmount
     this.assetAmount = assetAmount
     this.price = price
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
     this.asset = asset
   }

--- a/packages/protocol-explorer/src/domain/CloseWithDepositEvent.ts
+++ b/packages/protocol-explorer/src/domain/CloseWithDepositEvent.ts
@@ -14,7 +14,7 @@ export class CloseWithDepositEvent {
   public readonly collateralWithdrawAmount: BigNumber
   public readonly collateralToLoanRate: BigNumber // one unit of loanToken, denominated in collateralToken
   public readonly currentMargin: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
 
   constructor(
@@ -28,7 +28,7 @@ export class CloseWithDepositEvent {
     collateralWithdrawAmount: BigNumber,
     collateralToLoanRate: BigNumber,
     currentMargin: BigNumber,
-    timeStamp: Date,
+    blockNumber: BigNumber,
     txHash: string
   ) {
     this.user = user
@@ -41,7 +41,7 @@ export class CloseWithDepositEvent {
     this.collateralWithdrawAmount = collateralWithdrawAmount
     this.collateralToLoanRate = collateralToLoanRate
     this.currentMargin = currentMargin
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
   }
 }

--- a/packages/protocol-explorer/src/domain/CloseWithSwapEvent.ts
+++ b/packages/protocol-explorer/src/domain/CloseWithSwapEvent.ts
@@ -14,7 +14,7 @@ export class CloseWithSwapEvent {
   public readonly loanCloseAmount: BigNumber
   public readonly exitPrice: BigNumber // one unit of loanToken, denominated in collateralToken
   public readonly currentLeverage: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
 
   constructor(
@@ -28,7 +28,7 @@ export class CloseWithSwapEvent {
     loanCloseAmount: BigNumber,
     exitPrice: BigNumber,
     currentLeverage: BigNumber,
-    timeStamp: Date,
+    blockNumber: BigNumber,
     txHash: string
   ) {
     this.user = user
@@ -41,7 +41,7 @@ export class CloseWithSwapEvent {
     this.loanCloseAmount = loanCloseAmount
     this.exitPrice = exitPrice
     this.currentLeverage = currentLeverage
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
   }
 }

--- a/packages/protocol-explorer/src/domain/LiquidationEvent.ts
+++ b/packages/protocol-explorer/src/domain/LiquidationEvent.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from '@0x/utils'
 import Asset from 'bzx-common/src/assets/Asset'
+import { timeStamp } from 'console'
 
 export class LiquidationEvent {
   public static readonly topic0: string =
@@ -14,8 +15,9 @@ export class LiquidationEvent {
   public readonly collateralWithdrawAmount: BigNumber
   public readonly collateralToLoanRate: BigNumber // one unit of baseToken, denominated in quoteToken
   public readonly currentMargin: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
+  public readonly timeStamp?: Date
 
   constructor(
     user: string,
@@ -28,8 +30,9 @@ export class LiquidationEvent {
     collateralWithdrawAmount: BigNumber,
     collateralToLoanRate: BigNumber,
     currentMargin: BigNumber,
-    timeStamp: Date,
-    txHash: string
+    blockNumber: BigNumber,
+    txHash: string,
+    timeStamp?: Date
   ) {
     this.user = user
     this.liquidator = liquidator
@@ -41,7 +44,8 @@ export class LiquidationEvent {
     this.collateralWithdrawAmount = collateralWithdrawAmount
     this.collateralToLoanRate = collateralToLoanRate
     this.currentMargin = currentMargin
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
+    this.timeStamp = timeStamp
   }
 }

--- a/packages/protocol-explorer/src/domain/MintEvent.ts
+++ b/packages/protocol-explorer/src/domain/MintEvent.ts
@@ -8,7 +8,7 @@ export class MintEvent {
   public readonly tokenAmount: BigNumber
   public readonly assetAmount: BigNumber
   public readonly price: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
   public readonly asset: Asset
 
@@ -17,7 +17,7 @@ export class MintEvent {
     tokenAmount: BigNumber,
     assetAmount: BigNumber,
     price: BigNumber,
-    timeStamp: Date,
+    blockNumber: BigNumber,
     txHash: string,
     asset: Asset
   ) {
@@ -25,7 +25,7 @@ export class MintEvent {
     this.tokenAmount = tokenAmount
     this.assetAmount = assetAmount
     this.price = price
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
     this.asset = asset
   }

--- a/packages/protocol-explorer/src/domain/RolloverEvent.ts
+++ b/packages/protocol-explorer/src/domain/RolloverEvent.ts
@@ -1,0 +1,48 @@
+import { BigNumber } from '@0x/utils'
+import Asset from 'bzx-common/src/assets/Asset'
+
+
+export class RolloverEvent {
+  public static readonly topic0: string =
+    '0x21e656d09cbbafac02fd00fc98d308d0df53e46fa0a7b4358eca09302afc2e58'
+  public readonly user: string //indexed
+  public readonly caller: string //indexed
+  public readonly loanId: string //indexed
+  public readonly lender: string
+  public readonly loanToken: Asset
+  public readonly collateralToken: Asset
+  public readonly collateralAmountUsed: BigNumber
+  public readonly interestAmountAdded: BigNumber
+  public readonly loanEndTimestamp: Date
+  public readonly gasRebate: BigNumber 
+  public readonly blockNumber: BigNumber
+  public readonly txHash: string
+
+  constructor(
+    user: string,
+    caller: string,
+    loanId: string,
+    lender: string,
+    loanToken: Asset,
+    collateralToken: Asset,
+    collateralAmountUsed: BigNumber,
+    interestAmountAdded: BigNumber,
+    loanEndTimestamp: Date,
+    gasRebate: BigNumber,
+    blockNumber: BigNumber,
+    txHash: string
+  ) {
+    this.user = user
+    this.caller = caller
+    this.loanId = loanId
+    this.lender = lender
+    this.loanToken = loanToken
+    this.collateralToken = collateralToken
+    this.collateralAmountUsed = collateralAmountUsed
+    this.interestAmountAdded = interestAmountAdded
+    this.loanEndTimestamp = loanEndTimestamp
+    this.gasRebate = gasRebate
+    this.blockNumber = blockNumber
+    this.txHash = txHash
+  }
+}

--- a/packages/protocol-explorer/src/domain/TradeEvent.ts
+++ b/packages/protocol-explorer/src/domain/TradeEvent.ts
@@ -16,7 +16,7 @@ export class TradeEvent {
   public readonly entryPrice: BigNumber // one unit of baseToken, denominated in quoteToken
   public readonly entryLeverage: BigNumber
   public readonly currentLeverage: BigNumber
-  public readonly timeStamp: Date
+  public readonly blockNumber: BigNumber
   public readonly txHash: string
 
   constructor(
@@ -32,7 +32,7 @@ export class TradeEvent {
     entryPrice: BigNumber,
     entryLeverage: BigNumber,
     currentLeverage: BigNumber,
-    timeStamp: Date,
+    blockNumber: BigNumber,
     txHash: string
   ) {
     this.user = user
@@ -47,7 +47,7 @@ export class TradeEvent {
     this.entryPrice = entryPrice
     this.entryLeverage = entryLeverage
     this.currentLeverage = currentLeverage
-    this.timeStamp = timeStamp
+    this.blockNumber = blockNumber
     this.txHash = txHash
   }
 }

--- a/packages/protocol-explorer/src/layout/HeaderMenu.tsx
+++ b/packages/protocol-explorer/src/layout/HeaderMenu.tsx
@@ -7,7 +7,7 @@ export class HeaderMenu extends Component<IHeaderMenuProps> {
     const itemsMenu = [
       { id: 1, title: 'Stats', link: '/', external: false },
       { id: 2, title: 'Liquidations', link: '/liquidations', external: false },
-      { id: 3, title: 'Loan Params', link: '/loan-params', external: false },
+      // { id: 3, title: 'Loan Params', link: '/loan-params', external: false },
       // { id: 3, title: 'Staking', link: 'https://staking.bzx.network', external: true },
       { id: 4, title: 'Blog', link: 'https://bzx.network/blog/', external: true }
     ]

--- a/packages/protocol-explorer/src/pages/LiquidationsPage.tsx
+++ b/packages/protocol-explorer/src/pages/LiquidationsPage.tsx
@@ -118,7 +118,7 @@ export class LiquidationsPage extends Component<ILiquidationsPageProps, ILiquida
     const eventsWithDay = events.map(
       (e: { event: LiquidationEvent; repayAmountUsd: BigNumber }) => ({
         ...e,
-        day: Math.floor(e.event.timeStamp.getTime() / (1000 * 60 * 60 * 24))
+        day: Math.floor(e.event.timeStamp!.getTime() / (1000 * 60 * 60 * 24))
       })
     )
     const eventsWithDayByDay = groupBy(eventsWithDay, 'day')
@@ -204,7 +204,7 @@ export class LiquidationsPage extends Component<ILiquidationsPageProps, ILiquida
       event: LiquidationEvent
       repayAmountUsd: BigNumber
     }> = []
-    const liquidationEvents = await ExplorerProvider.Instance.getLiquidationHistory()
+    const liquidationEvents = await ExplorerProvider.Instance.getLiquidationHistoryWithTimestamps()
     const unhealthyLoansData = await ExplorerProvider.Instance.getBzxLoans(0, 500, true)
     const healthyLoansData = await ExplorerProvider.Instance.getBzxLoans(0, 500, false)
     const rolloversData = await ExplorerProvider.Instance.getRollovers(0, 500)
@@ -217,7 +217,8 @@ export class LiquidationsPage extends Component<ILiquidationsPageProps, ILiquida
       new BigNumber(0)
     )
     const liqudiations30d = liquidationEvents.filter(
-      (e: LiquidationEvent) => e.timeStamp.getTime() > new Date().setDate(new Date().getDate() - 30)
+      (e: LiquidationEvent) =>
+        e.timeStamp!.getTime() > new Date().setDate(new Date().getDate() - 30)
     )
     const transactionsCount30d = liqudiations30d.length
 
@@ -244,7 +245,7 @@ export class LiquidationsPage extends Component<ILiquidationsPageProps, ILiquida
           const swapToUsdHistoryRateRequest = await fetch(
             `https://api.bzx.network/v1/asset-history-price?asset=${
               e.loanToken === Asset.fWETH ? 'eth' : e.loanToken.toLowerCase()
-            }&date=${e.timeStamp.getTime()}`
+            }&date=${e.timeStamp!.getTime()}`
           )
           const swapToUsdHistoryRateResponse = (await swapToUsdHistoryRateRequest.json()).data
           if (!swapToUsdHistoryRateResponse) continue
@@ -458,11 +459,13 @@ export class LiquidationsPage extends Component<ILiquidationsPageProps, ILiquida
                       <div className="flex jc-c labels-container">
                         {this.assetsShown.map((e: Asset) => {
                           const assetDetails = AssetsDictionary.assets.get(e)
-                          return assetDetails && (
-                            <div key={assetDetails.bgBrightColor} className="label-chart">
-                              <span style={{ backgroundColor: assetDetails.bgBrightColor }} />
-                              {e}
-                            </div>
+                          return (
+                            assetDetails && (
+                              <div key={assetDetails.bgBrightColor} className="label-chart">
+                                <span style={{ backgroundColor: assetDetails.bgBrightColor }} />
+                                {e}
+                              </div>
+                            )
                           )
                         })}
                       </div>

--- a/packages/protocol-explorer/src/pages/SearchResultPage.tsx
+++ b/packages/protocol-explorer/src/pages/SearchResultPage.tsx
@@ -128,6 +128,9 @@ export class SearchResultPage extends Component<ISearchResultPageProps, ISearchR
     const tradeEvents = ExplorerProvider.Instance.getGridItems(
       await ExplorerProvider.Instance.getTradeHistory()
     )
+    const rolloverEvents = ExplorerProvider.Instance.getGridItems(
+      await ExplorerProvider.Instance.getRolloverHistory()
+    )
     const closeEvents = ExplorerProvider.Instance.getGridItems(
       await ExplorerProvider.Instance.getCloseWithSwapHistory()
     )
@@ -142,6 +145,7 @@ export class SearchResultPage extends Component<ISearchResultPageProps, ISearchR
       .concat(tradeEvents)
       .concat(closeWithDepositEvents)
       .concat(borrowEvents)
+      .concat(rolloverEvents)
 
     this._isMounted &&
       this.setState({

--- a/packages/protocol-explorer/src/pages/SearchResultPage.tsx
+++ b/packages/protocol-explorer/src/pages/SearchResultPage.tsx
@@ -1,65 +1,13 @@
 import React, { Component } from 'react'
 import { Header } from '../layout/Header'
-import ContractsSource from 'bzx-common/src/contracts/ContractsSource'
-import { LiquidationEvent } from '../domain/LiquidationEvent'
-import { BigNumber } from '@0x/utils'
 import { ITxRowProps } from '../components/TxRow'
-import configProviders from '../config/providers.json'
 import { TxGrid } from '../components/TxGrid'
-import { LoanGrid } from '../components/LoanGrid'
-import Asset from 'bzx-common/src/assets/Asset'
-import { Bar } from 'react-chartjs-2'
 import { Search } from '../components/Search'
-import { UnhealthyChart } from '../components/UnhealthyChart'
 import { RouteComponentProps } from 'react-router'
-import { TradeEvent } from '../domain/TradeEvent'
-import { CloseWithSwapEvent } from '../domain/CloseWithSwapEvent'
-import { CloseWithDepositEvent } from '../domain/CloseWithDepositEvent'
-import { BorrowEvent } from '../domain/BorrowEvent'
-import { BurnEvent } from '../domain/BurnEvent'
-import { MintEvent } from '../domain/MintEvent'
 import { ExplorerProvider } from '../services/ExplorerProvider'
 import { ExplorerProviderEvents } from '../services/events/ExplorerProviderEvents'
 import { Loader } from '../components/Loader'
-
-const getWeb3ProviderSettings = (networkId: number): string => {
-  let etherscanURL = ''
-  switch (networkId) {
-    case 1:
-      etherscanURL = 'https://etherscan.io/'
-      break
-    case 3:
-      etherscanURL = 'https://ropsten.etherscan.io/'
-      break
-    case 4:
-      etherscanURL = 'https://rinkeby.etherscan.io/'
-      break
-    case 42:
-      etherscanURL = 'https://kovan.etherscan.io/'
-      break
-    default:
-      etherscanURL = ''
-      break
-  }
-  return etherscanURL
-}
-
-const getNetworkIdByString = (networkName: string | undefined) => {
-  switch (networkName) {
-    case 'mainnet':
-      return 1
-    case 'ropsten':
-      return 3
-    case 'rinkeby':
-      return 4
-    case 'kovan':
-      return 42
-    default:
-      return 0
-  }
-}
-const networkName = process.env.REACT_APP_ETH_NETWORK
-const initialNetworkId = getNetworkIdByString(networkName)
+import { NavService } from '../services/NavService'
 
 interface MatchParams {
   filter: string
@@ -176,6 +124,8 @@ export class SearchResultPage extends Component<ISearchResultPageProps, ISearchR
         e.hash.toLowerCase() === filter.toLowerCase() ||
         e.account.toLowerCase() === filter.toLowerCase()
     )
+    NavService.Instance.History.push(`/search/${filter}`)
+
     this._isMounted &&
       this.setState({
         ...this.state,
@@ -197,9 +147,9 @@ export class SearchResultPage extends Component<ISearchResultPageProps, ISearchR
         </section>
         <section className="pt-90">
           <div className="container">
-            <h1>Result:</h1>
+            <h1 className="pb-45">Result:</h1>
             {this.state.isLoading ? (
-              <div className="pt-90 pb-45">
+              <div className="pt-45 pb-45">
                 <Loader quantityDots={5} sizeDots={'large'} title={'Loading'} isOverlay={false} />
               </div>
             ) : (

--- a/packages/protocol-explorer/src/pages/SearchResultPage.tsx
+++ b/packages/protocol-explorer/src/pages/SearchResultPage.tsx
@@ -154,7 +154,13 @@ export class SearchResultPage extends Component<ISearchResultPageProps, ISearchR
         </section>
         <section className="pt-90">
           <div className="container">
-            <h1 className="pb-45">Result:</h1>
+            {!ExplorerProvider.Instance.contractsSource ||
+            !ExplorerProvider.Instance.contractsSource.canWrite ? (
+              <h1 className="pb-45 flex jc-c">Please connect your wallet</h1>
+            ) : (
+              <h1 className="pb-45">Result:</h1>
+            )}
+
             {this.state.isLoading ? (
               <div className="pt-45 pb-45">
                 <Loader quantityDots={5} sizeDots={'large'} title={'Loading'} isOverlay={false} />

--- a/packages/protocol-explorer/src/pages/SearchResultPage.tsx
+++ b/packages/protocol-explorer/src/pages/SearchResultPage.tsx
@@ -69,6 +69,13 @@ export class SearchResultPage extends Component<ISearchResultPageProps, ISearchR
   }
 
   derivedUpdate = async () => {
+    if (
+      !ExplorerProvider.Instance.contractsSource ||
+      !ExplorerProvider.Instance.contractsSource.canWrite
+    ) {
+      this.props.doNetworkConnect()
+      return
+    }
     this.setState({ isLoading: true })
     const liquidationEvents = ExplorerProvider.Instance.getGridItems(
       await ExplorerProvider.Instance.getLiquidationHistory()

--- a/packages/protocol-explorer/src/pages/StatsPage.tsx
+++ b/packages/protocol-explorer/src/pages/StatsPage.tsx
@@ -18,6 +18,7 @@ import { ExplorerProvider } from '../services/ExplorerProvider'
 import { ExplorerProviderEvents } from '../services/events/ExplorerProviderEvents'
 import { NavService } from '../services/NavService'
 import { Loader } from '../components/Loader'
+import { RolloverEvent } from 'src/domain/RolloverEvent'
 
 interface MatchParams {
   token: string
@@ -101,6 +102,11 @@ export class StatsPage extends Component<IStatsPageProps, IStatsPageState> {
         (e: TradeEvent) => e.loanToken === this.state.asset
       )
     )
+    const rolloverEvents = ExplorerProvider.Instance.getGridItems(
+      (await ExplorerProvider.Instance.getRolloverHistory()).filter(
+        (e: RolloverEvent) => e.loanToken === this.state.asset
+      )
+    )
     const closeEvents = ExplorerProvider.Instance.getGridItems(
       (await ExplorerProvider.Instance.getCloseWithSwapHistory()).filter(
         (e: CloseWithSwapEvent) => e.loanToken === this.state.asset
@@ -125,6 +131,7 @@ export class StatsPage extends Component<IStatsPageProps, IStatsPageState> {
     const events: ITxRowProps[] = liquidationEvents
       .concat(closeEvents)
       .concat(tradeEvents)
+      .concat(rolloverEvents)
       .concat(closeWithDepositEvents)
       .concat(borrowEvents)
       .concat(mintEvents)

--- a/packages/protocol-explorer/src/services/ExplorerProvider.ts
+++ b/packages/protocol-explorer/src/services/ExplorerProvider.ts
@@ -340,6 +340,9 @@ export class ExplorerProvider {
     address: string,
     topic: string
   ): Promise<any> => {
+    // this method can return only first 1000 events
+    // so be careful with fromBlock → toBlock range 
+    // also, etherscan api allows only up to 5 request/sec
     const etherscanApiKey = configProviders.Etherscan_Api
     const etherscanApiUrl = `https://${
       networkName === 'kovan' ? 'api-kovan' : 'api'


### PR DESCRIPTION
All events are fetched using RPC `eth_getLogs` method. 
The only exclusion is `getLiquidationHistoryWithTimestamps` which is still fetched using etherscan API until we will provider our own blockNumber → timestamp dictionary at api.bzx.network 

https://app.clubhouse.io/bzx1/story/1391/search-field