### PR TITLE
Remove yield farming banners for Torque and Fulcrum

### DIFF
--- a/packages/fulcrum/package.json
+++ b/packages/fulcrum/package.json
@@ -50,7 +50,6 @@
     "react-modal": "^3.8.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "react-tippy": "^1.2.3",
     "react-tooltip": "^4.2.10",
     "recharts": "^1.5.0",
     "rxjs": "^6.5.2",

--- a/packages/fulcrum/src/layout/HeaderOps.tsx
+++ b/packages/fulcrum/src/layout/HeaderOps.tsx
@@ -8,14 +8,12 @@ import { ReactComponent as MenuIconOpen } from '../assets/images/ic_menu.svg'
 import { ReactComponent as MenuIconClose } from '../assets/images/ic_close.svg'
 import Footer from './Footer'
 import { SwitchButtonInput } from '../components/SwitchButtonInput'
-import { truncate } from 'fs'
-import { InfoBlock } from '../components/InfoBlock'
+
 export interface IHeaderOpsProps {
   doNetworkConnect: () => void
   isRiskDisclosureModalOpen: () => void
   isMobileMedia: boolean
   headerClass: string
-  //isV1ITokenInWallet: boolean;
 }
 
 interface IHeaderOpsState {
@@ -104,7 +102,6 @@ export class HeaderOps extends Component<IHeaderOpsProps, IHeaderOpsState> {
     }
 
     return (
-      <React.Fragment>
         <header className={`header ${this.props.headerClass}`}>
           <div className="header__row">
             <div className="header__left">
@@ -119,20 +116,6 @@ export class HeaderOps extends Component<IHeaderOpsProps, IHeaderOpsState> {
             </div>
           </div>
         </header>
-        <InfoBlock localstorageItemProp="fulcrum-page-info" isAccept={true}>
-          Earn farming rewards! When trading or borrowing you are earning vBZRX while your position
-          is open. Rewards are deposited weekly in your{' '}
-          <a href="https://staking.bzx.network" className="regular-link" target="blank">
-            staking dashboard
-          </a>
-          .
-        </InfoBlock>
-        {/* {this.props.isV1ITokenInWallet &&
-          <InfoBlock localstorageItemProp="v1Balance">
-            If you supplied assets to Fulcrum prior to September 2 you can access them on our <a href="https://legacy.fulcrum.trade/#/lend" className="disclosure-link">Legacy dApp</a>.
-          </InfoBlock>
-        } */}
-      </React.Fragment>
     )
   }
 
@@ -157,7 +140,6 @@ export class HeaderOps extends Component<IHeaderOpsProps, IHeaderOpsState> {
     const sidebarClass = !this.state.isMenuOpen ? 'sidebar_h' : 'sidebar_v'
 
     return (
-      <React.Fragment>
         <header className={`header ${this.props.headerClass}`}>
           <div className="header__row">
             <div className="header__left">
@@ -198,20 +180,6 @@ export class HeaderOps extends Component<IHeaderOpsProps, IHeaderOpsState> {
             </div>
           ) : null}
         </header>
-        <InfoBlock localstorageItemProp="fulcrum-page-info" isAccept={true}>
-          Earn farming rewards! When trading or borrowing you are earning vBZRX while your position
-          is open. Rewards are deposited weekly in your{' '}
-          <a href="https://staking.bzx.network" className="regular-link" target="blank">
-            staking dashboard
-          </a>
-          .
-        </InfoBlock>
-        {/* {this.props.isV1ITokenInWallet &&
-          <InfoBlock localstorageItemProp="v1Balance">
-            If you supplied assets to Fulcrum prior to September 2 you can access them on our <a href="https://legacy.fulcrum.trade/#/lend" className="disclosure-link">Legacy dApp</a>.
-          </InfoBlock>
-        } */}
-      </React.Fragment>
     )
   }
 

--- a/packages/fulcrum/src/pages/StatsPage.tsx
+++ b/packages/fulcrum/src/pages/StatsPage.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { StatsTokenGrid } from '../components/StatsTokenGrid'
-import { InfoBlock } from '../components/InfoBlock'
 
 import '../styles/pages/_stats-page.scss'
 

--- a/packages/fulcrum/src/react-app-env.d.ts
+++ b/packages/fulcrum/src/react-app-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="react-scripts" />
-declare module 'react-tippy'
 declare module 'react-intercom'
 
 declare namespace NodeJS {

--- a/packages/fulcrum/src/styles/index.scss
+++ b/packages/fulcrum/src/styles/index.scss
@@ -1,5 +1,3 @@
-@import '~react-tippy/dist/tippy.css';
-
 @import 'abstracts/functions';
 @import 'abstracts/mixins';
 @import 'abstracts/variables';

--- a/packages/protocol-explorer/package.json
+++ b/packages/protocol-explorer/package.json
@@ -33,7 +33,6 @@
     "react-intercom": "^1.0.15",
     "react-router": "^5.2.0",
     "react-router-dom": "^4.3.1",
-    "react-tippy": "^1.2.3",
     "rxjs": "^6.5.2",
     "web3-utils": "^1.3.0"
   },

--- a/packages/protocol-explorer/src/react-app-env.d.ts
+++ b/packages/protocol-explorer/src/react-app-env.d.ts
@@ -1,4 +1,3 @@
 /// <reference types="react-scripts" />
-declare module 'react-tippy'
 declare module 'node-fetch'
 declare module 'react-intercom'

--- a/packages/staking-dashboard/package.json
+++ b/packages/staking-dashboard/package.json
@@ -35,7 +35,6 @@
     "react-modal": "^3.8.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^4.3.1",
-    "react-tippy": "^1.2.3",
     "rxjs": "^6.5.2",
     "simplebar-react": "^2.2.0"
   },

--- a/packages/staking-dashboard/src/react-app-env.d.ts
+++ b/packages/staking-dashboard/src/react-app-env.d.ts
@@ -1,4 +1,3 @@
 /// <reference types="react-scripts" />
-declare module 'react-tippy'
 declare module 'node-fetch'
 declare module 'react-intercom'

--- a/packages/torque/package.json
+++ b/packages/torque/package.json
@@ -40,7 +40,6 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-sidebar": "^3.0.2",
-    "react-tippy": "^1.2.3",
     "rxjs": "^6.5.2",
     "squarelink": "^0.4.1",
     "walletlink": "^1.0.0",

--- a/packages/torque/src/layout/HeaderOps.tsx
+++ b/packages/torque/src/layout/HeaderOps.tsx
@@ -4,8 +4,6 @@ import { ProviderType } from '../domain/ProviderType'
 import { TorqueProvider } from '../services/TorqueProvider'
 import { HeaderLogo } from './HeaderLogo'
 import { HeaderMenu, IHeaderMenuProps } from './HeaderMenu'
-import { HeaderMenuToggle } from './HeaderMenuToggle'
-import { InfoBlock } from '../components/InfoBlock'
 
 import { ReactComponent as MenuIconOpen } from '../assets/images/ic_menu.svg'
 import { ReactComponent as MenuIconClose } from '../assets/images/ic_close.svg'
@@ -96,17 +94,6 @@ export class HeaderOps extends Component<IHeaderOpsProps, IHeaderOpsState> {
             </div> */}
           </div>
         </div>
-
-        {
-          <InfoBlock localstorageItemProp="torque-page-info" isAccept={true}>
-            Earn farming rewards! When trading or borrowing you are earning vBZRX while your
-            position is open. Rewards are deposited weekly in your{' '}
-            <a href="https://staking.bzx.network" className="regular-link" target="blank">
-              staking dashboard
-            </a>
-            .
-          </InfoBlock>
-        }
       </header>
     )
   }
@@ -149,14 +136,6 @@ export class HeaderOps extends Component<IHeaderOpsProps, IHeaderOpsState> {
             </div>
           ) : null}
         </header>
-        <InfoBlock localstorageItemProp="torque-page-info" isAccept={true}>
-          Earn farming rewards! When trading or borrowing you are earning vBZRX while your position
-          is open. Rewards are deposited weekly in your{' '}
-          <a href="https://staking.bzx.network" className="regular-link" target="blank">
-            staking dashboard
-          </a>
-          .
-        </InfoBlock>
       </React.Fragment>
     )
   }

--- a/packages/torque/src/react-app-env.d.ts
+++ b/packages/torque/src/react-app-env.d.ts
@@ -1,4 +1,3 @@
 /// <reference types="react-scripts" />
-declare module 'react-tippy'
 declare module 'node-fetch'
 declare module 'react-intercom'

--- a/packages/torque/src/styles/index.scss
+++ b/packages/torque/src/styles/index.scss
@@ -1,5 +1,3 @@
-@import '~react-tippy/dist/tippy.css';
-
 @import 'abstracts/functions';
 @import 'abstracts/mixins';
 @import 'abstracts/variables';

--- a/yarn.lock
+++ b/yarn.lock
@@ -19091,11 +19091,6 @@ popper.js@1.14.3:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
   integrity sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU=
 
-popper.js@^1.11.1:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
-  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
-
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -20690,13 +20685,6 @@ react-smooth@^1.0.5:
     prop-types "^15.6.0"
     raf "^3.4.0"
     react-transition-group "^2.5.0"
-
-react-tippy@^1.2.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-tippy/-/react-tippy-1.4.0.tgz#e8a8b4085ec985e5c94fe128918b733b588a1465"
-  integrity sha512-r/hM5XK9Ztr2ZY7IWKuRmISTlUPS/R6ddz6PO2EuxCgW+4JBcGZRPU06XcVPRDCOIiio8ryBQFrXMhFMhsuaHA==
-  dependencies:
-    popper.js "^1.11.1"
 
 react-tooltip@^4.2.10:
   version "4.2.10"


### PR DESCRIPTION
Also, I removed unused dependency for tooltips. We use `react-tooltip` instead
https://app.clubhouse.io/bzx1/story/1424/remove-banner-remove-yield-on-torque-fulcrum