### PR TITLE
fix(staking): avoid showing negative reward values

### DIFF
--- a/packages/staking-dashboard/README.md
+++ b/packages/staking-dashboard/README.md
@@ -23,6 +23,15 @@ The following must be done in the contract repo folder.
 - The local fork will be available on `localhost:8545`
 - Provider, like Metamask should be pointed to `localhost:8545`
 
+**Metamask example**
+
+Go to Settings -> networks -> add network
+
+- Network name: **Localhost 8545**
+- RPC url: **http://localhost:8545**
+- Chain ID: **1**
+- Currency Symbol: **ETH**
+
 ### Commands and scripts
 
 Run from the **contract repo folder**.

--- a/packages/staking-dashboard/src/App/Staking/Rewards/StakingRewards.tsx
+++ b/packages/staking-dashboard/src/App/Staking/Rewards/StakingRewards.tsx
@@ -34,9 +34,7 @@ export function StakingRewards({ vm }: { vm: RewardsVM }) {
           <b>BZRX</b> rewards include{' '}
           <b className="txt-positive">{numberUtils.format(rewards.vestedBzrxInRewards)}</b>{' '}
           <i>vested BZRX</i> from your staked vBZRX and{' '}
-          <b className="txt-positive">
-            {numberUtils.format(rewards.bzrx.minus(rewards.vestedBzrxInRewards))}
-          </b>{' '}
+          <b className="txt-positive">{numberUtils.format(rewards.actualBzrxStakingRewards)}</b>{' '}
           BZRX of <i>actual staking rewards</i>.
         </p>
       )}

--- a/packages/staking-dashboard/src/stores/StakingStore/Rewards.ts
+++ b/packages/staking-dashboard/src/stores/StakingStore/Rewards.ts
@@ -67,6 +67,21 @@ export default class Rewards {
   }
 
   /**
+   * BZRX rewards include vbzrx staked that have vested + actual rewards.
+   * This is the actual staking reward part.
+   * Note: under certain circumstances, the vestedBzrxInRewards may be bigger
+   * than the total rewards. If that happens we prevent having a negative value
+   * and set it to 0.
+   */
+  get actualBzrxStakingRewards() {
+    const amount = this.bzrx.minus(this.vestedBzrxInRewards)
+    if (amount.isNegative()) {
+      return new BigNumber(0)
+    }
+    return amount
+  }
+
+  /**
    * Helper to set the value of one prop through a mobx action.
    */
   public set(prop: rewardsProp, value: any) {


### PR DESCRIPTION
BZRX rewards include vbzrx staked that have vested + actual rewards.

Under certain circumstances, the vestedBzrxInRewards may be bigger than the total rewards by a minor difference.
If that happens we prevent showing a negative value and set it to 0.